### PR TITLE
Add MIT license and update site metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,21 @@
-Imitation is the highest form of flattery. Feel free to use this without any copyright concerns.
+MIT License
+
+Copyright (c) 2026 Shishir Dey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shishir-dey.github.io",
   "version": "1.0.0",
-  "description": "",
+  "description": "Personal Website of Shishir Dey",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -18,7 +18,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/shishir-dey/shishir-dey.github.io/issues"
   },

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,97 +3,97 @@
 	xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	<url>
 		<loc>https://shishir-dey.github.io/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>1.0</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/libautomotive/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.9</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/libpower/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.9</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/libiot/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
+		<changefreq>weekly</changefreq>
+		<priority>0.9</priority>
+	</url>
+	<url>
+		<loc>https://shishir-dey.github.io/libmodbuzz/</loc>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.9</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/stm32-devops-template/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.8</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/stm32-rust-template/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.8</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/pcb-dev-dsPIC30F3011/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.7</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/pcb-dev-dsPIC30F6010A/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.7</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/vhdl-samples/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.6</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/LISA/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.6</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/cad-alarm-clock/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.5</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/Clippy/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.4</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/ngspiceX/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.4</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/open_battery/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.9</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/Rhythm/</loc>
-		<lastmod>2026-02-13</lastmod>
-		<changefreq>weekly</changefreq>
-		<priority>0.4</priority>
-	</url>
-	<url>
-		<loc>https://shishir-dey.github.io/schematic/</loc>
-		<lastmod>2026-02-13</lastmod>
+		<lastmod>2026-04-05</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.4</priority>
 	</url>


### PR DESCRIPTION
Replace the placeholder LICENSE with an MIT license. Update package.json to set a project description and change the license field to MIT. Refresh lastmod timestamps in public/sitemap.xml to 2026-04-05 for multiple pages and add a new libmodbuzz entry.