### PR TITLE
Refresh sitemap and add project entries

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,97 +3,121 @@
 	xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	<url>
 		<loc>https://shishir-dey.github.io/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>1.0</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/libautomotive/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.9</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/libpower/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.9</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/libiot/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.9</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/libmodbuzz/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
+		<changefreq>weekly</changefreq>
+		<priority>0.9</priority>
+	</url>
+	<url>
+		<loc>https://shishir-dey.github.io/DatasheetXML/</loc>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.9</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/stm32-devops-template/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.8</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/stm32-rust-template/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
+		<changefreq>weekly</changefreq>
+		<priority>0.8</priority>
+	</url>
+	<url>
+		<loc>https://shishir-dey.github.io/s32-template/</loc>
+		<lastmod>2026-08-14</lastmod>
+		<changefreq>weekly</changefreq>
+		<priority>0.8</priority>
+	</url>
+	<url>
+		<loc>https://shishir-dey.github.io/spi-flash/</loc>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.8</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/pcb-dev-dsPIC30F3011/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.7</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/pcb-dev-dsPIC30F6010A/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
+		<changefreq>weekly</changefreq>
+		<priority>0.7</priority>
+	</url>
+	<url>
+		<loc>https://shishir-dey.github.io/pcb-mcu-stm32c0/</loc>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.7</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/vhdl-samples/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.6</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/LISA/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.6</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/cad-alarm-clock/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.5</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/Clippy/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.4</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/ngspiceX/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.4</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/open_battery/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.9</priority>
 	</url>
 	<url>
 		<loc>https://shishir-dey.github.io/Rhythm/</loc>
-		<lastmod>2026-04-05</lastmod>
+		<lastmod>2026-08-14</lastmod>
 		<changefreq>weekly</changefreq>
 		<priority>0.4</priority>
 	</url>


### PR DESCRIPTION
Updated the sitemap timestamps to 2026-08-14 and added newly published project URLs for DatasheetXML, s32-template, spi-flash, and pcb-mcu-stm32c0.